### PR TITLE
add glob option for initializing extera

### DIFF
--- a/R/extendr-wrappers.R
+++ b/R/extendr-wrappers.R
@@ -14,7 +14,9 @@ rust_render_template <- function(template, outfile, context_string) .Call(wrap__
 
 RustExTera <- new.env(parent = emptyenv())
 
-RustExTera$new <- function() .Call(wrap__RustExTera__new)
+RustExTera$default <- function() .Call(wrap__RustExTera__default)
+
+RustExTera$new <- function(dir) .Call(wrap__RustExTera__new, dir)
 
 RustExTera$add_string_templates <- function(templates) .Call(wrap__RustExTera__add_string_templates, self, templates)
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ pak::pak("kbvernon/extera")
 
 ## Example
 
-Everything in `extera` revolves around the `ExTera` object.
+Everything in `extera` revolves around the `ExTera` object. You can
+initialize an `ExTera` with an empty template library simply by calling
+`ExTera$new()`.
 
 ``` r
 library(extera)
@@ -56,8 +58,8 @@ tera
 #> ── ExTera ──
 #> 
 #> Template library:
-#> • star-wars
 #> • hello-world
+#> • star-wars
 
 starwars <- dplyr::starwars[c("name", "films", "homeworld", "species")]
 
@@ -67,6 +69,72 @@ tera$render_to_string(
   people = starwars
 )
 #> Rendered star-wars template:
+#> 
+#> <h2>Humans of A New Hope</h2>
+#> <ol>
+#>   <li>Luke Skywalker (Tatooine)</li>
+#>   <li>Darth Vader (Tatooine)</li>
+#>   <li>Leia Organa (Alderaan)</li>
+#>   <li>Owen Lars (Tatooine)</li>
+#>   <li>Beru Whitesun Lars (Tatooine)</li>
+#>   <li>Biggs Darklighter (Tatooine)</li>
+#>   <li>Obi-Wan Kenobi (Stewjon)</li>
+#>   <li>Wilhuff Tarkin (Eriadu)</li>
+#>   <li>Han Solo (Corellia)</li>
+#>   <li>Wedge Antilles (Corellia)</li>
+#>   <li>Raymus Antilles (Alderaan)</li>
+#> </ol>
+#> 
+```
+
+If you have a complicated directory system with nested templates and
+inheritance patterns, you may find it easier to initialize an `ExTera`
+by specifying the directory with a glob containing the `*` wildcard to
+indicate any number of template files.
+
+``` r
+template_dir <- file.path(tempdir(), "templates")
+
+dir.create(template_dir)
+dir.create(file.path(template_dir, "subdirectory"))
+
+cat(
+  '<p>Hello {{ x }}. This is {{ y }}.</p>',
+  file = file.path(template_dir, "hello-world.html")
+)
+
+cat(
+  '<h2>{{ title }}</h2>
+<ol>
+{%- for person in people %}
+  {%- if person.films is containing("A New Hope") %}
+  {%- if person.species and person.species is containing("Human") %}
+  <li>{{ person.name }} ({{ person.homeworld }})</li>
+  {%- endif %}
+  {%- endif %}
+{%- endfor %}
+</ol>
+',
+  file = file.path(template_dir, "subdirectory", "star-wars.html")
+)
+
+glob <- file.path(template_dir, "*.html")
+
+tera <- ExTera$new(glob)
+tera
+#> 
+#> ── ExTera ──
+#> 
+#> Template library:
+#> • hello-world.html
+#> • subdirectory/star-wars.html
+
+tera$render_to_string(
+  "subdirectory/star-wars.html",
+  title = "Humans of A New Hope",
+  people = starwars
+)
+#> Rendered subdirectory/star-wars.html template:
 #> 
 #> <h2>Humans of A New Hope</h2>
 #> <ol>

--- a/README.qmd
+++ b/README.qmd
@@ -35,9 +35,11 @@ pak::pak("kbvernon/extera")
 
 ## Example
 
-Everything in `extera` revolves around the `ExTera` object. 
+Everything in `extera` revolves around the `ExTera` object. You can initialize
+an `ExTera` with an empty template library simply by calling `ExTera$new()`.
 
 ```{r}
+#| label: basic-example
 library(extera)
 
 tera <- ExTera$new()
@@ -63,6 +65,50 @@ starwars <- dplyr::starwars[c("name", "films", "homeworld", "species")]
 
 tera$render_to_string(
   "star-wars",
+  title = "Humans of A New Hope",
+  people = starwars
+)
+```
+
+If you have a complicated directory system with nested templates and inheritance 
+patterns, you may find it easier to initialize an `ExTera` by specifying the 
+directory with a glob containing the `*` wildcard to indicate any number of 
+template files.
+
+```{r}
+#| label: glob-example
+template_dir <- file.path(tempdir(), "templates")
+
+dir.create(template_dir)
+dir.create(file.path(template_dir, "subdirectory"))
+
+cat(
+  '<p>Hello {{ x }}. This is {{ y }}.</p>',
+  file = file.path(template_dir, "hello-world.html")
+)
+
+cat(
+  '<h2>{{ title }}</h2>
+<ol>
+{%- for person in people %}
+  {%- if person.films is containing("A New Hope") %}
+  {%- if person.species and person.species is containing("Human") %}
+  <li>{{ person.name }} ({{ person.homeworld }})</li>
+  {%- endif %}
+  {%- endif %}
+{%- endfor %}
+</ol>
+',
+  file = file.path(template_dir, "subdirectory", "star-wars.html")
+)
+
+glob <- file.path(template_dir, "*.html")
+
+tera <- ExTera$new(glob)
+tera
+
+tera$render_to_string(
+  "subdirectory/star-wars.html",
   title = "Humans of A New Hope",
   people = starwars
 )

--- a/man/ExTera.Rd
+++ b/man/ExTera.Rd
@@ -21,6 +21,27 @@ template.
 Templating syntax is described in the \href{https://keats.github.io/tera/docs}{Tera docs}.
 }
 \examples{
+# initialize ExTera from directory with glob
+template_dir <- file.path(tempdir(), "templates")
+
+dir.create(template_dir)
+
+tmp <- file.path(
+  template_dir,
+  "hello-world-template.html"
+)
+
+cat(
+  '<p>Hello {{ x }}. This is {{ y }}.</p>',
+  file = tmp
+)
+
+glob <- file.path(template_dir, "*.html")
+
+tera <- ExTera$new(dir = glob)
+tera
+
+# initialize ExTera with empty library
 tera <- ExTera$new()
 
 # from string template
@@ -36,24 +57,13 @@ tera$render_to_string(
 )
 
 # from file template
-outdir <- tempdir()
-
-tmp <- file.path(
-  outdir,
-  "hello-world-template.html"
-)
-
-cat(
-  '<p>Hello {{ x }}. This is {{ y }}.</p>',
-  file = tmp
-)
 
 tera$add_file_templates(
   "hello-world.html" = tmp
 )
 
 outfile <- file.path(
-  outdir,
+  template_dir,
   "hello-world-rendered.html"
 )
 
@@ -87,9 +97,29 @@ readLines(outfile, warn = FALSE)
 \if{html}{\out{<a id="method-ExTera-new"></a>}}
 \if{latex}{\out{\hypertarget{method-ExTera-new}{}}}
 \subsection{Method \code{new()}}{
-Create a new \code{ExTera} object.
+Create a new \code{ExTera} object. Will populate template library with files
+in \code{dir} if specified.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{ExTera$new()}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{ExTera$new(dir = NULL)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{dir}}{character scalar, a glob pattern with \code{*} wildcards indicating
+a potentially nested directory containing multiple file templates. If
+\code{NULL} (the default), an \code{ExTera} with an empty library is initialized.
+See details for more information.}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Details}{
+The glob pattern \verb{templates/*.html} will match all files with the
+.html extension located directly inside the \code{templates} folder, while the
+glob pattern \verb{templates/**/*.html} will match all files with the .html
+extension directly inside or in a subdirectory of \code{templates}. The
+default naming convention is to give each template their full relative
+path from \code{templates} or whatever the directory is called.
 }
 
 \subsection{Returns}{

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -10,8 +10,17 @@ struct RustExTera(Tera);
 
 #[extendr]
 impl RustExTera {
-    fn new() -> RustExTera {
+    fn default() -> RustExTera {
         let tera = Tera::default();
+        RustExTera(tera)
+    }
+
+    fn new(dir: &str) -> RustExTera {
+        let tera = match Tera::new(dir) {
+            Ok(t) => t,
+            Err(e) => throw_r_error(&format!("{}", e)),
+        };
+
         RustExTera(tera)
     }
 
@@ -24,11 +33,7 @@ impl RustExTera {
 
         match self.0.add_raw_templates(template_tuples) {
             Ok(_) => Rbool::true_value(),
-            Err(e) => throw_r_error(&format!(
-                "Could not add templates '{:?}': {}",
-                templates.names().unwrap().collect::<Vec<_>>(),
-                e
-            )),
+            Err(e) => throw_r_error(&format!("{}", e)),
         }
     }
 
@@ -42,11 +47,7 @@ impl RustExTera {
 
         match self.0.add_template_files(template_tuples) {
             Ok(_) => Rbool::true_value(),
-            Err(e) => throw_r_error(&format!(
-                "Could not add templates '{:?}': {}",
-                templates.names().unwrap().collect::<Vec<_>>(),
-                e
-            )),
+            Err(e) => throw_r_error(&format!("{}", e)),
         }
     }
 
@@ -94,10 +95,7 @@ impl RustExTera {
 fn rust_render_template(template: &str, outfile: &str, context_string: &str) -> Rbool {
     let template_content = match fs::read_to_string(template) {
         Ok(content) => content,
-        Err(e) => throw_r_error(&format!(
-            "Could not read template file '{}': {}",
-            template, e
-        )),
+        Err(e) => throw_r_error(&format!("{}", e)),
     };
 
     let mut tera = Tera::default();
@@ -110,17 +108,14 @@ fn rust_render_template(template: &str, outfile: &str, context_string: &str) -> 
 
     let file = match fs::File::create(outfile) {
         Ok(f) => f,
-        Err(e) => throw_r_error(&format!(
-            "Could not create output file '{}': {}",
-            outfile, e
-        )),
+        Err(e) => throw_r_error(&format!("{}", e)),
     };
 
     let mut writer = BufWriter::new(file);
 
     match tera.render_to("template", &context, &mut writer) {
         Ok(_) => Rbool::true_value(),
-        Err(e) => throw_r_error(&format!("Unable to render template to file: {}", e)),
+        Err(e) => throw_r_error(&format!("{}", e)),
     }
 }
 


### PR DESCRIPTION
From the [tera api docs](https://docs.rs/tera/latest/tera/struct.Tera.html#impl-Tera): 

> For example, the glob pattern templates/*.html will match all files with the .html extension located directly inside the templates folder, while the glob pattern templates/**/*.html will match all files with the .html extension directly inside or in a subdirectory of templates.